### PR TITLE
Revert "regex control character detection"

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -735,12 +735,6 @@ function getLogFiles (callback) {
 }
 
 var server = http.createServer(function (request, response) {
-  
-  if ('/[\x00-\x1F\x7F-\x9F]/'.test(request)) {
-     log('warn', logsystem, 'Server is under attack - regex detected control characters!')
-  }
-  request = request.replace(/[\x00-\x1F\x7F-\x9F]/g, "");
-  
   if (request.method.toUpperCase() === 'OPTIONS') {
     response.writeHead('204', 'No Content', {
       'access-control-allow-origin': '*',


### PR DESCRIPTION
Reverts turtlecoin/node-turtle-pool#56
The regex stuff doesn't work because request objects are weird. Also, when checking my logs, the server marks the requests as malformed so it should be fine without this.